### PR TITLE
Handle empty datetime gracefully

### DIFF
--- a/src/ApiConnectors/BrowseDataApiConnector.php
+++ b/src/ApiConnectors/BrowseDataApiConnector.php
@@ -69,9 +69,7 @@ class BrowseDataApiConnector extends BaseApiConnector
     {
         Assert::minCount($columns, 1);
         Assert::allIsInstanceOf($columns, BrowseColumn::class);
-        if(count($sortFields)) {
-            Assert::allIsInstanceOf($sortFields, BrowseSortField::class);
-        }
+        Assert::allIsInstanceOf($sortFields, BrowseSortField::class);
 
         $requestBrowseData = new BrowseData($code, $columns, $sortFields);
 

--- a/src/Mappers/BrowseDataMapper.php
+++ b/src/Mappers/BrowseDataMapper.php
@@ -85,7 +85,7 @@ class BrowseDataMapper extends BaseMapper
      *
      * @param string $type
      * @param string $value
-     * @return mixed
+     * @return string|\DateTimeInterface|null|float
      * @throws Exception
      */
     private static function parseBrowseDataValue(string $type, string $value)

--- a/src/Util.php
+++ b/src/Util.php
@@ -62,6 +62,10 @@ final class Util
      */
     public static function parseDateTime(string $dateString)
     {
+        if($dateString === '') {
+          return null;
+        }
+      
         $date = \DateTimeImmutable::createFromFormat("YmdHis", $dateString);
 
         if (false === $date) {

--- a/src/Util.php
+++ b/src/Util.php
@@ -56,14 +56,12 @@ final class Util
     /**
      * Parse a date time string from a Twinfield XML.
      *
-     * @param string $dateString
-     * @return \DateTimeImmutable
      * @throws Exception
      */
-    public static function parseDateTime(string $dateString)
+    public static function parseDateTime(string $dateString): ?\DateTimeImmutable
     {
-        if($dateString === '') {
-          return null;
+        if ($dateString === '') {
+            return null;
         }
       
         $date = \DateTimeImmutable::createFromFormat("YmdHis", $dateString);


### PR DESCRIPTION
When Twinfield returns an empty date it should be converted to NULL.